### PR TITLE
Create builders for `Completion` and `Edit` structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "darling"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +343,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +491,7 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 name = "openai"
 version = "1.0.0-alpha.2"
 dependencies = [
+ "derive_builder",
  "dotenvy",
  "openai_bootstrap",
  "openai_proc_macros",
@@ -734,6 +807,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["ai", "high-level", "machine-learning"]
 [dependencies]
 serde_json = "1.0"
 dotenvy = "0.15"
+derive_builder = "0.12"
 
 [dependencies.reqwest]
 version = "0.11"

--- a/examples/completions_cli/Cargo.lock
+++ b/examples/completions_cli/Cargo.lock
@@ -79,6 +79,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "darling"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +500,7 @@ checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 name = "openai"
 version = "1.0.0-alpha.2"
 dependencies = [
+ "derive_builder",
  "dotenvy",
  "openai_bootstrap",
  "openai_proc_macros",
@@ -741,6 +814,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/examples/completions_cli/src/main.rs
+++ b/examples/completions_cli/src/main.rs
@@ -1,8 +1,5 @@
 use dotenvy::dotenv;
-use openai::{
-    completions::{Completion, CreateCompletionRequestBody},
-    models::ModelID,
-};
+use openai::{completions::Completion, models::ModelID};
 use std::io::stdin;
 
 #[tokio::main]
@@ -17,15 +14,14 @@ async fn main() {
 
         stdin().read_line(&mut prompt).unwrap();
 
-        let completion = Completion::new(&CreateCompletionRequestBody {
-            model: ModelID::TextDavinci003,
-            prompt: &prompt,
-            max_tokens: Some(1024),
-            ..Default::default()
-        })
-        .await
-        .unwrap()
-        .unwrap();
+        let completion = Completion::builder()
+            .model(ModelID::TextDavinci003)
+            .prompt(&prompt)
+            .max_tokens(1024)
+            .create()
+            .await
+            .unwrap()
+            .unwrap();
 
         let response = &completion.choices.first().unwrap().text;
 

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -15,7 +15,7 @@ pub struct Completion {
     pub usage: Usage,
 }
 
-impl<'a> Completion {
+impl Completion {
     /// Creates a completion for the provided prompt and parameters
     async fn new(body: &CreateCompletionRequestBody<'_>) -> ApiResponseOrError<Self> {
         if let Some(enabled) = body.stream {
@@ -27,7 +27,7 @@ impl<'a> Completion {
         openai_post("completions", body).await
     }
 
-    pub fn builder() -> CompletionBuilder<'a> {
+    pub fn builder<'a>() -> CompletionBuilder<'a> {
         CompletionBuilder::default()
     }
 }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -2,6 +2,7 @@
 //! and can also return the probabilities of alternative tokens at each position.
 
 use super::{models::ModelID, openai_post, ApiResponseOrError, Usage};
+use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -14,9 +15,9 @@ pub struct Completion {
     pub usage: Usage,
 }
 
-impl Completion {
+impl<'a> Completion {
     /// Creates a completion for the provided prompt and parameters
-    pub async fn new(body: &CreateCompletionRequestBody<'_>) -> ApiResponseOrError<Self> {
+    async fn new(body: &CreateCompletionRequestBody<'_>) -> ApiResponseOrError<Self> {
         if let Some(enabled) = body.stream {
             if enabled {
                 todo!("the `stream` field is not yet implemented");
@@ -24,6 +25,10 @@ impl Completion {
         }
 
         openai_post("completions", body).await
+    }
+
+    pub fn builder() -> CompletionBuilder<'a> {
+        CompletionBuilder::default()
     }
 }
 
@@ -35,7 +40,10 @@ pub struct CompletionChoice {
     pub finish_reason: String,
 }
 
-#[derive(Serialize, Default)]
+#[derive(Serialize, Default, Builder)]
+#[builder(pattern = "owned")]
+#[builder(name = "CompletionBuilder")]
+#[builder(setter(strip_option))]
 pub struct CreateCompletionRequestBody<'a> {
     /// ID of the model to use.
     /// You can use the [List models](https://beta.openai.com/docs/api-reference/models/list)
@@ -49,15 +57,18 @@ pub struct CreateCompletionRequestBody<'a> {
     /// Note that <|endoftext|> is the document separator that the model sees during training,
     /// so if a prompt is not specified the model will generate as if from the beginning of a new document.
     #[serde(skip_serializing_if = "str::is_empty")]
+    #[builder(default)]
     pub prompt: &'a str,
     /// The suffix that comes after a completion of inserted text.
     #[serde(skip_serializing_if = "str::is_empty")]
+    #[builder(default)]
     pub suffix: &'a str,
     /// The maximum number of [tokens](https://beta.openai.com/tokenizer) to generate in the completion.
     ///
     /// The token count of your prompt plus `max_tokens` cannot exceed the model's context length.
     /// Most models have a context length of 2048 tokens (except for the newest models, which support 4096).
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
     pub max_tokens: Option<u16>,
     /// What [sampling temperature](https://towardsdatascience.com/how-to-sample-from-language-models-682bceb97277) to use.
     /// Higher values means the model will take more risks.
@@ -65,6 +76,7 @@ pub struct CreateCompletionRequestBody<'a> {
     ///
     /// We generally recommend altering this or `top_p` but not both.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
     pub temperature: Option<f32>,
     /// An alternative to sampling with temperature, called nucleus sampling,
     /// where the model considers the results of the tokens with top_p probability mass.
@@ -72,17 +84,20 @@ pub struct CreateCompletionRequestBody<'a> {
     ///
     /// We generally recommend altering this or `temperature` but not both.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
     pub top_p: Option<f32>,
     /// How many completions to generate for each prompt.
     ///
     /// **Note:** Because this parameter generates many completions, it can quickly consume your token quota.
     /// Use carefully and ensure that you have reasonable settings for `max_tokens` and `stop`.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
     pub n: Option<u16>,
     /// Whether to stream back partial progress. If set, tokens will be sent as data-only
     /// [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format)
     /// as they become available, with the stream terminated by a `data: [DONE]` message.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
     pub stream: Option<bool>,
     /// Include the log probabilities on the logprobs most likely tokens, as well the chosen tokens.
     /// For example, if logprobs is 5, the API will return a list of the 5 most likely tokens.
@@ -91,13 +106,16 @@ pub struct CreateCompletionRequestBody<'a> {
     /// The maximum value for `logprobs` is 5.
     /// If you need more than this, please contact us through our Help center and describe your use case.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
     pub logprobs: Option<u8>,
     /// Echo back the prompt in addition to the completion
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
     pub echo: Option<bool>,
     /// Up to 4 sequences where the API will stop generating further tokens.
     /// The returned text will not contain the stop sequence.
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
     pub stop: Vec<&'a str>,
     /// Number between -2.0 and 2.0.
     /// Positive values penalize new tokens based on whether they appear in the text so far,
@@ -105,6 +123,7 @@ pub struct CreateCompletionRequestBody<'a> {
     ///
     /// [See more information about frequency and presence penalties](https://beta.openai.com/docs/api-reference/parameter-details).
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
     pub presence_penalty: Option<i8>,
     /// Number between -2.0 and 2.0.
     /// Positive values penalize new tokens based on their existing frequency in the text so far,
@@ -112,6 +131,7 @@ pub struct CreateCompletionRequestBody<'a> {
     ///
     /// [See more information about frequency and presence penalties](https://beta.openai.com/docs/api-reference/parameter-details).
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
     pub frequency_penalty: Option<i8>,
     /// Generates `best_of` completions server-side and returns the "best" (the one with the highest log probability per token).
     /// Results cannot be streamed.
@@ -122,6 +142,7 @@ pub struct CreateCompletionRequestBody<'a> {
     /// **Note:** Because this parameter generates many completions, it can quickly consume your token quota.
     /// Use carefully and ensure that you have reasonable settings for `max_tokens` and `stop`.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
     pub best_of: Option<u16>,
     /// Modify the likelihood of specified tokens appearing in the completion.
     ///
@@ -133,11 +154,19 @@ pub struct CreateCompletionRequestBody<'a> {
     ///
     /// As an example, you can pass `{"50256": -100}` to prevent the <|endoftext|> token from being generated.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[builder(default)]
     pub logit_bias: HashMap<&'a str, i16>,
     /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
     /// [Learn more](https://beta.openai.com/docs/guides/safety-best-practices/end-user-ids).
     #[serde(skip_serializing_if = "str::is_empty")]
+    #[builder(default)]
     pub user: &'a str,
+}
+
+impl CompletionBuilder<'_> {
+    pub async fn create(self) -> ApiResponseOrError<Completion> {
+        Completion::new(&self.build().unwrap()).await
+    }
 }
 
 #[cfg(test)]
@@ -149,16 +178,15 @@ mod tests {
     async fn completion() {
         dotenv().ok();
 
-        let completion = Completion::new(&CreateCompletionRequestBody {
-            model: ModelID::TextDavinci003,
-            prompt: "Say this is a test",
-            max_tokens: Some(7),
-            temperature: Some(0.0),
-            ..Default::default()
-        })
-        .await
-        .unwrap()
-        .unwrap();
+        let completion = Completion::builder()
+            .model(ModelID::TextDavinci003)
+            .prompt("Say this is a test")
+            .max_tokens(7)
+            .temperature(0.0)
+            .create()
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(
             completion.choices.first().unwrap().text,


### PR DESCRIPTION
This pull requests adds `CompletionBuilder` and `EditBuilder`, which allows you to create completions and edits with the builder pattern. There are no builder structures for other structures like `Embeddings` and `Model` because they don't have very many fields. Here is an example of making a `Completion` with this PR:

```rs
let completion = Completion::builder()
    .model(ModelID::TextDavinci003)
    .prompt("Say this is a test")
    .max_tokens(7)
    .temperature(0.0)
    .create()
    .await
    .unwrap()
    .unwrap();
```