### PR TITLE
ChatCompletionMessage.name -> ChatCompletionMessage.user_name refactor

### DIFF
--- a/examples/chat_cli/src/main.rs
+++ b/examples/chat_cli/src/main.rs
@@ -13,7 +13,7 @@ async fn main() {
     let mut messages = vec![ChatCompletionMessage {
         role: ChatCompletionMessageRole::System,
         content: "You are a large language built into a command line interface as an example of what the `openai` Rust library made by Valentine Briese can do.".to_string(),
-        name: None,
+        user_name: None,
     }];
 
     loop {
@@ -26,7 +26,7 @@ async fn main() {
         messages.push(ChatCompletionMessage {
             role: ChatCompletionMessageRole::User,
             content: user_message_content,
-            name: None,
+            user_name: None,
         });
 
         let chat_completion = ChatCompletion::builder(ModelID::Gpt3_5Turbo, messages.clone())

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -30,7 +30,7 @@ pub struct ChatCompletionMessage {
     pub content: String,
     /// The name of the user in a multi-user chat
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub user_name: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Copy)]
@@ -138,7 +138,7 @@ mod tests {
             [ChatCompletionMessage {
                 role: ChatCompletionMessageRole::User,
                 content: "Hello!".to_string(),
-                name: None,
+                user_name: None,
             }],
         )
         .temperature(0.0)

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -29,7 +29,7 @@ pub struct ChatCompletionMessage {
     /// The contents of the message
     pub content: String,
     /// The name of the user in a multi-user chat
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", rename(serialize = "name", deserialize = "user_name"))]
     pub user_name: Option<String>,
 }
 


### PR DESCRIPTION
`name` is kind of ambiguous, might as well make the property name self-explanatory. 
Thanks for including the comment in the struct. 

Cheers