### PR TITLE
fix(error): make error type public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-use openai_bootstrap::{authorization, ApiResponse, OpenAiError, BASE_URL};
+use openai_bootstrap::{authorization, ApiResponse, BASE_URL};
+pub use openai_bootstrap::OpenAiError;
 use reqwest::{Client, Method, RequestBuilder};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 


### PR DESCRIPTION
hey! thanks for this cool project, i really appreciate the approach. was working on adding error handling to the chat example w/thiserror and found that the error type wasn't public. would be very helpful if it was :)

happy to contribute the error handling in the example as well if you'd like, just let me know