### PR TITLE
Add feature flags to use native-tls or rustls

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,5 +26,7 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
     - name: Build
       run: cargo build --verbose
-    - name: Run tests
+    - name: Run tests (native-tls)
       run: cargo test --verbose
+    - name: Run tests (rustls)
+      run: cargo test --verbose --no-default-features --features=rustls

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ai", "high-level", "machine-learning", "openai", "library"]
 [dependencies]
 serde_json = "1.0.94"
 derive_builder = "0.12.0"
-reqwest = { version = "0.11.14", features = ["json"] }
+reqwest = { version = "0.11.14", default-features = false, features = ["json"], optional = true }
 serde = { version = "1.0.157", features = ["derive"] }
 
 [dev-dependencies]
@@ -30,3 +30,10 @@ documentation = "https://valentinegb.github.io/openai/"
 edition = "2021"
 repository = "https://github.com/valentinegb/openai"
 license = "MIT"
+
+[features]
+default = ["native-tls"]
+
+native-tls = [ "reqwest/native-tls" ]
+
+rustls = [ "reqwest/rustls-tls" ]


### PR DESCRIPTION
Also adds an extra test step to the CI workflow to run tests using `rustls` instead of `native-tls`