### PR TITLE
Add image generation and its editing/variation endpoints

### DIFF
--- a/src/images.rs
+++ b/src/images.rs
@@ -1,0 +1,124 @@
+//! Given a prompt and/or an input image, the model will generate a new image.
+//! Related guide: [Image generation](https://platform.openai.com/docs/guides/images)
+
+use super::{openai_post, ApiResponseOrError, OpenAiError};
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+pub mod edits;
+pub mod variations;
+
+#[derive(Deserialize, Clone)]
+pub struct Image {
+    pub created: usize,
+    pub data: Vec<ImageData>
+}
+
+#[derive(Deserialize, Clone)]
+pub struct ImageData {
+    pub url: String
+}
+
+#[derive(Serialize, Clone, Default, Debug)]
+pub enum ImageSize {
+    #[serde(rename = "256x256")]
+    Small,
+    #[serde(rename = "512x512")]
+    Medium,
+    #[default]
+    #[serde(rename = "1024x1024")]
+    Large,
+}
+
+#[derive(Serialize, Clone, Default, Debug)]
+pub enum ImageFormat {
+    #[default]
+    #[serde(rename = "url")]
+    Url,
+    #[serde(rename = "b64_json")]
+    Base64Json,
+}
+
+#[derive(Serialize, Builder, Debug, Clone)]
+#[builder(pattern = "owned")]
+#[builder(name = "ImageBuilder")]
+#[builder(setter(strip_option, into))]
+pub struct ImageRequest {
+    /// A text description of the desired image(s).
+    /// The maximum length is 1000 characters.
+    pub prompt: String,
+
+    /// The number of images to generate.
+    /// Must be between 1 and 10.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into = false), default)]
+    pub n: Option<u16>,
+
+    /// The size of the generated images.
+    /// Must be one of `256x256`, `512x512`, or `1024x1024`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub size: Option<ImageSize>,
+
+    /// The format in which the generated images are returned.
+    /// Must be one of `url` or `b64_json`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub response_format: Option<ImageFormat>,
+
+    /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    /// [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub user: Option<String>,
+}
+
+impl Image {
+    async fn create(request: &ImageRequest) -> ApiResponseOrError<Self> {
+        let response: Result<Self, OpenAiError> = openai_post(
+            "images/generations",
+            request
+        ).await?;
+
+        Ok(match response {
+            Ok(image) => Ok(image),
+            Err(_) => response,
+        })
+    }
+
+    pub fn builder(prompt: &str) -> ImageBuilder {
+        ImageBuilder::create_empty()
+            .prompt(prompt)
+    }
+}
+
+impl ImageBuilder {
+    pub async fn create(self) -> ApiResponseOrError<Image> {
+        Image::create(&self.build().unwrap()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::set_key;
+    use dotenvy::dotenv;
+    use std::env;
+
+    #[tokio::test]
+    #[ignore]
+    async fn image() {
+        dotenv().ok();
+        set_key(env::var("OPENAI_KEY").unwrap());
+
+        let image = Image::builder("A cute baby sea otter")
+            .n(2)
+            .size(ImageSize::Large)
+            .create()
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(image.data.len() > 0)
+    }
+}

--- a/src/images/edits.rs
+++ b/src/images/edits.rs
@@ -1,0 +1,108 @@
+//! Creates an edited or extended image given an original image and a prompt.
+
+use super::{openai_post, ApiResponseOrError, OpenAiError, ImageData, ImageFormat, ImageSize};
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Clone)]
+pub struct ImageEdit {
+    pub created: usize,
+    pub data: Vec<ImageData>
+}
+
+#[derive(Serialize, Builder, Debug, Clone)]
+#[builder(pattern = "owned")]
+#[builder(name = "ImageEditBuilder")]
+#[builder(setter(strip_option, into))]
+pub struct ImageEditRequest {
+    /// The image to edit.
+    /// Must be a valid PNG file, less than 4MB, and square.
+    /// If mask is not provided, image must have transparency, which will be used as the mask.
+    pub image: String,
+
+    /// An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where `image` should be edited.
+    /// Must be a valid PNG file, less than 4MB, and have the same dimensions as `image`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into = false), default)]
+    pub mask: Option<String>,
+
+    /// A text description of the desired image(s).
+    /// The maximum length is 1000 characters.
+    pub prompt: String,
+
+    /// The number of images to generate. 
+    /// Must be between 1 and 10.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into = false), default)]
+    pub n: Option<u16>,
+
+    /// The size of the generated images.
+    /// Must be one of `256x256`, `512x512`, or `1024x1024`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub size: Option<ImageSize>,
+
+    /// The format in which the generated images are returned.
+    /// Must be one of `url` or `b64_json`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub response_format: Option<ImageFormat>,
+
+    /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    /// [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub user: Option<String>,
+}
+
+impl ImageEdit {
+    async fn create(request: &ImageEditRequest) -> ApiResponseOrError<Self> {
+        let response: Result<Self, OpenAiError> = openai_post(
+            "images/edits",
+            request
+        ).await?;
+
+        Ok(match response {
+            Ok(image) => Ok(image),
+            Err(_) => response,
+        })
+    }
+
+    pub fn builder(image: &str, prompt: &str) -> ImageEditBuilder {
+        ImageEditBuilder::create_empty()
+            .image(image)
+            .prompt(prompt)
+    }
+}
+
+impl ImageEditBuilder {
+    pub async fn create(self) -> ApiResponseOrError<ImageEdit> {
+        ImageEdit::create(&self.build().unwrap()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::set_key;
+    use dotenvy::dotenv;
+    use std::env;
+
+    #[tokio::test]
+    #[ignore]
+    async fn image() {
+        dotenv().ok();
+        set_key(env::var("OPENAI_KEY").unwrap());
+
+        let image = ImageEdit::builder("@otter.png", "A cute baby sea otter wearing a beret")
+            .mask("@mask.png".to_owned())
+            .n(2)
+            .size(ImageSize::Large)
+            .create()
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(image.data.len() > 0)
+    }
+}

--- a/src/images/variations.rs
+++ b/src/images/variations.rs
@@ -1,0 +1,95 @@
+//! Creates a variation of a given image.
+
+use super::{openai_post, ApiResponseOrError, OpenAiError, ImageData, ImageFormat, ImageSize};
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Clone)]
+pub struct ImageVariation {
+    pub created: usize,
+    pub data: Vec<ImageData>
+}
+
+#[derive(Serialize, Builder, Debug, Clone)]
+#[builder(pattern = "owned")]
+#[builder(name = "ImageVariationBuilder")]
+#[builder(setter(strip_option, into))]
+pub struct ImageVariationRequest {
+    /// The image to use as the basis for the variation(s).
+    /// Must be a valid PNG file, less than 4MB, and square.
+    pub image: String,
+
+    /// The number of images to generate.
+    /// Must be between 1 and 10.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into = false), default)]
+    pub n: Option<u16>,
+
+    /// The size of the generated images.
+    /// Must be one of `256x256`, `512x512`, or `1024x1024`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub size: Option<ImageSize>,
+
+    /// The format in which the generated images are returned.
+    /// Must be one of `url` or `b64_json`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub response_format: Option<ImageFormat>,
+
+    /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    /// [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub user: Option<String>,
+}
+
+impl ImageVariation {
+    async fn create(request: &ImageVariationRequest) -> ApiResponseOrError<Self> {
+        let response: Result<Self, OpenAiError> = openai_post(
+            "images/variations",
+            request
+        ).await?;
+
+        Ok(match response {
+            Ok(image) => Ok(image),
+            Err(_) => response,
+        })
+    }
+
+    pub fn builder(image: &str) -> ImageVariationBuilder {
+        ImageVariationBuilder::create_empty()
+            .image(image)
+    }
+}
+
+impl ImageVariationBuilder {
+    pub async fn create(self) -> ApiResponseOrError<ImageVariation> {
+        ImageVariation::create(&self.build().unwrap()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::set_key;
+    use dotenvy::dotenv;
+    use std::env;
+
+    #[tokio::test]
+    #[ignore]
+    async fn image() {
+        dotenv().ok();
+        set_key(env::var("OPENAI_KEY").unwrap());
+
+        let image = ImageVariation::builder("@otter.png")
+            .n(2)
+            .size(ImageSize::Large)
+            .create()
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(image.data.len() > 0)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod edits;
 pub mod embeddings;
 pub mod models;
 pub mod moderations;
+pub mod images;
 
 const BASE_URL: &str = "https://api.openai.com/v1/";
 


### PR DESCRIPTION
In my pull request, I just added:
1. Generating a new image based on a given prompt and/or an input 
2. Creating an edited or extended image given an original image and a prompt.

The modifications to the code provide two new features for image manipulation to OpenAI API users. They allow the generation of new images based on a given prompt and/or an input image and the creation of edited or extended images given an original image and a prompt. The new code is modular, with each feature defined in a separate struct and associated functions. The code is also tested and documented, making it easier for users to understand and use the new features.