### PR TITLE
Basic Azure OpenAI Service support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1.0.94"
 derive_builder = "0.12.0"
 reqwest = { version = "0.11.14", default-features = false, features = ["json"], optional = true }
 serde = { version = "1.0.157", features = ["derive"] }
+once_cell = "1.17.1"
 
 [dev-dependencies]
 dotenvy = "0.15.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,18 @@ pub mod embeddings;
 pub mod models;
 pub mod moderations;
 
-static BASE_URL: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new("https://api.openai.com/v1/".to_string()));
+static BASE_URL: Lazy<Mutex<String>> =
+    Lazy::new(|| Mutex::new("https://api.openai.com/v1/".to_string()));
 
 static API_KEY: Mutex<String> = Mutex::new(String::new());
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum ApiType {
+    OpenAi,
+    Azure,
+}
+
+static API_TYPE: Mutex<ApiType> = Mutex::new(ApiType::OpenAi);
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct OpenAiError {
@@ -53,16 +62,23 @@ where
     T: DeserializeOwned,
 {
     let client = Client::new();
-    let mut request = client.request(method, BASE_URL.lock().unwrap().to_owned() + route);
+    let mut url = BASE_URL.lock().unwrap().to_owned() + route;
+    let api_type = *API_TYPE.lock().unwrap();
+    if api_type == ApiType::Azure {
+        url += "?api-version=2023-03-15-preview";
+    }
+
+    let mut request = client.request(method, url);
 
     request = builder(request);
 
-    let api_response: ApiResponse<T> = request
-        .header(AUTHORIZATION, format!("Bearer {}", API_KEY.lock().unwrap()))
-        .send()
-        .await?
-        .json()
-        .await?;
+    let key = API_KEY.lock().unwrap();
+    if api_type == ApiType::OpenAi {
+        request = request.header(AUTHORIZATION, format!("Bearer {}", key))
+    } else {
+        request = request.header("api-key", key.to_string())
+    }
+    let api_response: ApiResponse<T> = request.send().await?.json().await?;
 
     match api_response {
         ApiResponse::Ok(t) => Ok(Ok(t)),
@@ -103,6 +119,21 @@ pub fn set_key(value: String) {
     *API_KEY.lock().unwrap() = value;
 }
 
+/// Sets the API type that is used
+///
+/// ## Examples
+///
+/// Use a custom Azure OpenAI endpoint
+///
+/// ```rust
+/// use openai::{set_base_url,ApiType};
+///
+/// set_base_url(ApiType::Azure);
+/// ```
+pub fn set_api_type(value: ApiType) {
+    *API_TYPE.lock().unwrap() = value;
+}
+
 /// Sets the base URL for all OpenAI API functions.
 ///
 /// ## Examples
@@ -112,7 +143,7 @@ pub fn set_key(value: String) {
 /// ```rust
 /// use openai::set_base_url;
 ///
-/// set_base_url("https://docs-test-001.openai.azure.com/openai/deployments/gpt-3.5-turbo/chat/completions?api-version=2023-03-15-preview");
+/// set_base_url("https://docs-test-001.openai.azure.com/openai/deployments/my-own-gpt-3.5");
 /// ```
 pub fn set_base_url(value: String) {
     *BASE_URL.lock().unwrap() = value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use once_cell::sync::Lazy;
 use reqwest::{header::AUTHORIZATION, Client, Method, RequestBuilder};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::sync::Mutex;
@@ -9,7 +10,7 @@ pub mod embeddings;
 pub mod models;
 pub mod moderations;
 
-const BASE_URL: &str = "https://api.openai.com/v1/";
+static BASE_URL: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new("https://api.openai.com/v1/".to_string()));
 
 static API_KEY: Mutex<String> = Mutex::new(String::new());
 
@@ -52,7 +53,7 @@ where
     T: DeserializeOwned,
 {
     let client = Client::new();
-    let mut request = client.request(method, BASE_URL.to_owned() + route);
+    let mut request = client.request(method, BASE_URL.lock().unwrap().to_owned() + route);
 
     request = builder(request);
 
@@ -100,4 +101,19 @@ where
 /// ```
 pub fn set_key(value: String) {
     *API_KEY.lock().unwrap() = value;
+}
+
+/// Sets the base URL for all OpenAI API functions.
+///
+/// ## Examples
+///
+/// Use a custom Azure OpenAI endpoint
+///
+/// ```rust
+/// use openai::set_base_url;
+///
+/// set_base_url("https://docs-test-001.openai.azure.com/openai/deployments/gpt-3.5-turbo/chat/completions?api-version=2023-03-15-preview");
+/// ```
+pub fn set_base_url(value: String) {
+    *BASE_URL.lock().unwrap() = value;
 }


### PR DESCRIPTION
- Make BASE_URL configurable

Fixes #56
Fixes #57

This is different from #57 in that it uses once_cell instead of lazy_static for
initialization of the default BASE_URL value.

- Add basic support for Azure OpenAI Service

Apart from choosing the BASE_URL there are some other small differences between
the way you need to call the Azure service. So this adds a API_TYPE. The same
approach is used in the official openai Python library.
